### PR TITLE
configure and cmake: add formal options to configure the borg

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -22,6 +22,8 @@ OPTION(SUPPORT_STATS_FRONTEND "Support for statistics front end; requires sqlite
 OPTION(SUPPORT_TEST_FRONTEND "Support for test front end." OFF)
 OPTION(SUPPORT_WINDOWS_FRONTEND "Support for windows front end." OFF)
 OPTION(SUPPORT_STATS_BACKEND "Enable backend support for statistics and related debugging commands.  Implied by SUPPORT_STATS_FRONTEND." OFF)
+OPTION(SUPPORT_BORG "Support for Borg." ON)
+OPTION(SUPPORT_BORG_HIGH_SCORES "Borg characters allowed in high scores." OFF)
 
 # By default, generate a self-contained build left where the build was run.
 # If not using the Windows front end, the executable will have hardwired
@@ -310,9 +312,15 @@ SET_TARGET_PROPERTIES(OurCoreLib PROPERTIES C_STANDARD 99)
 SET(ANGBAND_CORE_INCLUDE_DIRS "${CMAKE_CURRENT_SOURCE_DIR}/src")
 SET(ANGBAND_CORE_LINK_LIBRARIES "")
 
-TARGET_INCLUDE_DIRECTORIES(OurCoreLib PRIVATE
-    ${ANGBAND_CORE_INCLUDE_DIRS}
-)
+IF(SUPPORT_BORG)
+    TARGET_INCLUDE_DIRECTORIES(OurCoreLib PRIVATE
+        ${ANGBAND_CORE_INCLUDE_DIRS}
+    )
+    TARGET_COMPILE_DEFINITIONS(OurCoreLib PRIVATE -D ALLOW_BORG)
+    IF(SUPPORT_BORG_HIGH_SCORES)
+        TARGET_COMPILE_DEFINITIONS(OurCoreLib PRIVATE -D SCORE_BORGS)
+    ENDIF()
+ENDIF()
 
 IF(SUPPORT_SDL_SOUND OR SUPPORT_SDL2_SOUND)
     ADD_LIBRARY(OurSoundSupportLib OBJECT
@@ -372,6 +380,9 @@ IF(SUPPORT_WINDOWS_FRONTEND)
     INCLUDE(src/cmake/macros/WINDOWS_Frontend.cmake)
     CONFIGURE_WINDOWS_FRONTEND(OurExecutable NO)
     CONFIGURE_WINDOWS_FRONTEND(OurCoreLib YES)
+    IF(SUPPORT_BORG)
+        TARGET_COMPILE_DEFINITIONS(OurExecutable PRIVATE -D ALLOW_BORG)
+    ENDIF()
 ENDIF()
 
 IF(SUPPORT_SDL_SOUND)

--- a/configure.ac
+++ b/configure.ac
@@ -241,6 +241,23 @@ if test "x$wsetgid" == "xyes"; then
 	AC_DEFINE(SETGID, 1, [Define if running as a central install on a multiuser system that has setresgid or setegid support.])
 fi
 
+dnl Borg
+AC_ARG_ENABLE(borg,
+	[AS_HELP_STRING([--enable-borg], [enable Borg (default enabled)])],
+	[enable_borg=$enableval],
+	[enable_borg=yes])
+AC_ARG_ENABLE(borg_high_scores,
+	[AS_HELP_STRING([--enable-borg-high-scores], [allow Borg characters to appear in the high scores (default: disabled)])],
+	[enable_borg_high_scores=$enableval],
+	[enable_borg_high_scores=no])
+
+if test x"$enable_borg" = xyes ; then
+	AC_DEFINE(ALLOW_BORG, 1, [Define if you want Borg support compiled.])
+fi
+if test x"$enable_borg_high_scores" = xyes; then
+	AC_DEFINE(SCORE_BORGS, 1, [Define if you Borg characters to appear in the high scores.])
+fi
+
 dnl Frontends
 AC_ARG_ENABLE(curses,
 	[AS_HELP_STRING([--enable-curses], [enable Curses frontend (default: enabled)])],

--- a/src/Makefile
+++ b/src/Makefile
@@ -8,7 +8,7 @@ OBJECTS = $(ANGFILES) $(ZFILES)
 SRCS    = ${OBJECTS:.o=.c} ${MAINFILES:.o=.c}
 PROG    = $(PROGNAME)$(PROG_SUFFIX)
 # Will dynamically generate version.h with the build number.
-CFLAGS += -DHAVE_VERSION_H -DALLOW_BORG
+CFLAGS += -DHAVE_VERSION_H
 
 CFLAGS += -I. -fPIC -std=c99 -O0
 # Replace above line with the two below and then look at gmon.out


### PR DESCRIPTION
In both, default to compiling the borg but not including borg results in the high scores.  Attempts to address Gwarl's request here, http://angband.oook.cz/forum/showpost.php?p=161342&postcount=6 .