### PR TITLE
Borg: avoid redundant declaration warnings from gcc

### DIFF
--- a/src/borg/borg1.c
+++ b/src/borg/borg1.c
@@ -2607,7 +2607,6 @@ int sv_potion_boldness;
 int sv_potion_detect_invis;
 int sv_potion_enlightenment;
 int sv_potion_slime_mold;
-int sv_potion_berserk;
 int sv_potion_infravision;
 int sv_potion_inc_exp;
 

--- a/src/borg/borg1.h
+++ b/src/borg/borg1.h
@@ -134,7 +134,6 @@ extern int sv_potion_boldness;
 extern int sv_potion_detect_invis;
 extern int sv_potion_enlightenment;
 extern int sv_potion_slime_mold;
-extern int sv_potion_berserk;
 extern int sv_potion_infravision;
 extern int sv_potion_inc_exp;
 
@@ -252,7 +251,6 @@ extern int sv_wand_drain_life;
 
 extern int sv_dagger;
 
-extern int sv_sling;
 extern int sv_sling;
 extern int sv_short_bow;
 extern int sv_long_bow;

--- a/src/borg/borg4.c
+++ b/src/borg/borg4.c
@@ -619,8 +619,6 @@ static const int borg_adj_con_mhp[STAT_RANGE] =
 };
 
 
-extern const int adj_str_hold[STAT_RANGE];
-extern const int adj_str_blow[STAT_RANGE];
 int borg_calc_blows(int extra_blows);
 
 

--- a/src/borg/borg6.h
+++ b/src/borg/borg6.h
@@ -96,7 +96,6 @@ extern bool borg_flow_stair_more(int why, bool sneak, bool brave);
 
 extern bool borg_flow_glyph(int why);
 extern bool borg_flow_light(int why);
-extern bool borg_check_LIGHT_only(void);
 extern bool borg_backup_swap(int p);
 extern bool borg_flow_recover(bool viewable, int dist);
 

--- a/src/borg/borg8.h
+++ b/src/borg/borg8.h
@@ -26,8 +26,6 @@
   */
 extern bool borg_think_store(void);
 
-extern bool borg_caution_phase(int, int);
-extern bool borg_LIGHT_beam(bool simulation);
 /*
  * Think about the dungeon
  */


### PR DESCRIPTION
Seen when compiling with Makefile.std.  For an example, see https://github.com/angband/angband/actions/runs/5978415797/job/16220463266 .