### PR TITLE
borg: avoid mismatched format string warnings

### DIFF
--- a/src/borg/borg-io.c
+++ b/src/borg/borg-io.c
@@ -293,9 +293,9 @@ errr borg_keypress(keycode_t k)
     /* Hack -- note the keypress */
     if (borg_cfg[BORG_VERBOSE]) {
         if (k >= 32 && k <= 126) {
-            borg_note(format("& Key <%c> (0x%02X)", k, k));
+            borg_note(format("& Key <%c> (0x%02lX)", (char)k, (long int)k));
         } else {
-            borg_note(format("& Key <0x%02X>", k));
+            borg_note(format("& Key <0x%02lX>", (long int)k));
         }
     }
 

--- a/src/borg/borg-item-wear.c
+++ b/src/borg/borg-item-wear.c
@@ -774,7 +774,7 @@ bool borg_backup_swap(int p)
         && b_p <= (borg_fighting_unique ? ((avoidance * 2) / 3)
                                         : (avoidance / 2))) {
         /* Log */
-        borg_note(format("# Swapping backup.  (%d < %d).", b_p, p));
+        borg_note(format("# Swapping backup.  (%ld < %d).", (long int)b_p, p));
 
         /* Wear it */
         borg_keypress('w');

--- a/src/borg/borg-junk.c
+++ b/src/borg/borg-junk.c
@@ -443,7 +443,7 @@ bool borg_crush_junk(void)
             continue;
 
         /* Message */
-        borg_note(format("# Junking junk (valued at %d)", value));
+        borg_note(format("# Junking junk (valued at %ld)", (long int)value));
         /* Message */
         borg_note(format("# Destroying %s.", item->desc));
 
@@ -1039,8 +1039,8 @@ bool borg_crush_slow(void)
         borg_item *item = &borg_items[b_i];
 
         /* Message */
-        borg_note(format("# Junking %ld power (slow) value %d",
-            (long int)b_p - borg.power, item->value));
+        borg_note(format("# Junking %ld power (slow) value %ld",
+            (long int)b_p - borg.power, (long int)item->value));
 
         /* Attempt to consume it */
         if (borg_consume(b_i))

--- a/src/borg/borg-log.c
+++ b/src/borg/borg-log.c
@@ -426,9 +426,10 @@ void borg_write_map(bool ask)
 
     /* Dump the Time Variables */
     file_putf(borg_map_file, "Time on this panel; %d\n", borg.time_this_panel);
-    file_putf(borg_map_file, "Time on this level; %d\n", borg_t - borg_began);
-    file_putf(borg_map_file, "Time since left town; %d\n",
-        borg_time_town + (borg_t - borg_began));
+    file_putf(borg_map_file, "Time on this level; %ld\n",
+        (long int)(borg_t - borg_began));
+    file_putf(borg_map_file, "Time since left town; %ld\n",
+        (long int)(borg_time_town + (borg_t - borg_began)));
     file_putf(borg_map_file, "Food in town; %d\n", borg_food_onsale);
     file_putf(borg_map_file, "Fuel in town; %d\n", borg_fuel_onsale);
     file_putf(borg_map_file, "Borg_no_retreat; %d\n", borg.no_retreat);
@@ -697,8 +698,8 @@ void borg_display_item(struct object *item2, int n)
     /* Describe fully */
     prt(item->desc, 2, j);
 
-    prt(format("kind = %-5d  level = %-4d  tval = %-5d  sval = %-5d",
-            item->kind, item->level, item->tval, item->sval),
+    prt(format("kind = %-5lu  level = %-4d  tval = %-5d  sval = %-5d",
+            (unsigned long int)item->kind, item->level, item->tval, item->sval),
         4, j);
 
     prt(format("number = %-3d  wgt = %-6d  ac = %-5d    damage = %dd%d",
@@ -1072,12 +1073,12 @@ void borg_status(void)
             Term_putstr(60, 10, -1, COLOUR_WHITE, "Time:");
 
             Term_putstr(54, 11, -1, COLOUR_SLATE, "This Level         ");
-            Term_putstr(
-                65, 11, -1, COLOUR_WHITE, format("%d", borg_t - borg_began));
+            Term_putstr(65, 11, -1, COLOUR_WHITE,
+                format("%ld", (long int)(borg_t - borg_began)));
 
             Term_putstr(54, 12, -1, COLOUR_SLATE, "Since Town         ");
             Term_putstr(65, 12, -1, COLOUR_WHITE,
-                format("%d", borg_time_town + (borg_t - borg_began)));
+                format("%ld", (long int)(borg_time_town + (borg_t - borg_began))));
 
             Term_putstr(54, 13, -1, COLOUR_SLATE, "This Panel         ");
             Term_putstr(

--- a/src/borg/borg-think-dungeon-util.c
+++ b/src/borg/borg-think-dungeon-util.c
@@ -858,7 +858,8 @@ bool borg_leave_level(bool bored)
     if (!g && (borg_t - borg_began) > borg_time_to_stay_on_level(bored)) {
         /* Note */
         borg_note(format(
-            "# Spent too long (%d) on level, leaving.", borg_t - borg_began));
+            "# Spent too long (%ld) on level, leaving.",
+            (long int)(borg_t - borg_began)));
 
         /* if we are trying not to go down, go up*/
         if (try_not_to_descend)

--- a/src/borg/borg-update.c
+++ b/src/borg/borg-update.c
@@ -510,9 +510,10 @@ static void borg_update_map(void)
 
                 /* Check for memory overflow */
                 if (borg_wank_num == AUTO_VIEW_MAX) {
-                    borg_note(format("# Wank problem at grid (%d,%d) m:%d "
+                    borg_note(format("# Wank problem at grid (%d,%d) m:%lu "
                                      "o:%d, borg at (%d,%d)",
-                        y, x, g.m_idx, g.first_kind ? g.first_kind->kidx : 0,
+                        y, x, (unsigned long int)g.m_idx,
+                        g.first_kind ? g.first_kind->kidx : 0,
                         borg.c.y, borg.c.x));
                     borg_oops("too many objects...");
                 }
@@ -1550,8 +1551,9 @@ void borg_update(void)
             continue;
 
         /* Note */
-        borg_note(format("# Expiring an object '%s' (%d) at (%d,%d)",
-            (take->kind->name), take->kind->kidx, take->y, take->x));
+        borg_note(format("# Expiring an object '%s' (%lu) at (%d,%d)",
+            (take->kind->name), (unsigned long int)take->kind->kidx,
+            take->y, take->x));
 
         /* Kill the object */
         borg_delete_take(i);

--- a/src/borg/borg.c
+++ b/src/borg/borg.c
@@ -500,8 +500,13 @@ static struct keypress borg_inkey_hack(int flush_first)
     if (!borg.in_shop && (ch_evt.type & EVT_KBRD) && ch_evt.key.code > 0
         && ch_evt.key.code != 10) {
         /* Oops */
-        borg_note(format(
-            "# User key press <%d><%c>", ch_evt.key.code, ch_evt.key.code));
+        if (ch_evt.key.code >= 32 && ch_evt.key.code <= 126) {
+            borg_note(format("# User key press <%lu><%c>",
+                (unsigned long int)ch_evt.key.code, (char)ch_evt.key.code));
+        } else {
+            borg_note(format("# User key press <%lu>",
+                (unsigned long int)ch_evt.key.code));
+        }
         borg_note(format("# Key type was <%d><%c>", ch_evt.type, ch_evt.type));
         borg_oops("user abort");
 
@@ -1805,8 +1810,8 @@ void do_cmd_borg(void)
                     failpercent = (borg_spell_fail_rate(as->spell_enum));
 
                     Term_putstr(1, ii++, -1, COLOUR_WHITE,
-                        format("%s, %s, attempted %d times, fail rate:%d",
-                            as->name, legal, as->times, failpercent));
+                        format("%s, %s, attempted %ld times, fail rate:%d",
+                            as->name, legal, (long int)as->times, failpercent));
                 }
                 get_com(
                     "Exam spell books.  Press any key for next book.", &cmd);


### PR DESCRIPTION
These are from the Nintendo 3DS builds and are mostly due to int32_t being a synonym for long on that platform.