### PR TITLE
Borg: fix dump of traits in borg_write_map()

### DIFF
--- a/src/borg/borg-log.c
+++ b/src/borg/borg-log.c
@@ -481,11 +481,11 @@ void borg_write_map(bool ask)
     }
 
     /* Dump the borg.trait[] information */
-    itemm = z_info->k_max;
-    to    = z_info->k_max + BI_MAX;
+    itemm = 0;
+    to    = BI_MAX;
     for (; itemm < to; itemm++) {
         file_putf(borg_map_file, "skill %d (%s) value= %d.\n", itemm,
-            prefix_pref[itemm - z_info->k_max], borg.has[itemm]);
+            prefix_pref[itemm], borg.trait[itemm]);
     }
 
 #if 0


### PR DESCRIPTION
On macOS with an executable compiled with "-fsanitize=address -fsanitize=undefined", caused a crash when a borg-controlled character died.  The cause of the crash was "AddressSanitizer: heap-buffer-overflow".  The offending address was zero bytes to the right of the 1640 bytes allocated for borg.has.