### PR TITLE
Borg: fix vault excavation logic

### DIFF
--- a/src/borg/borg-flow-misc.c
+++ b/src/borg/borg-flow-misc.c
@@ -881,9 +881,7 @@ bool borg_flow_vault(int nearness)
             uint8_t feat = borg_grids[y][x].feat;
 
             /* only deal with excavatable walls */
-            if (feat != FEAT_FLOOR 
-                && feat != FEAT_LAVA 
-                && feat != FEAT_RUBBLE
+            if (feat != FEAT_RUBBLE
                 && feat != FEAT_QUARTZ 
                 && feat != FEAT_MAGMA
                 && feat != FEAT_QUARTZ_K 

--- a/src/borg/borg-think-dungeon-util.c
+++ b/src/borg/borg-think-dungeon-util.c
@@ -960,9 +960,7 @@ bool borg_excavate_vault(int range)
                 continue;
 
             /* only deal with excavatable walls */
-            if (borg_grids[y][x].feat != FEAT_FLOOR
-                && borg_grids[y][x].feat != FEAT_LAVA
-                && borg_grids[y][x].feat != FEAT_GRANITE
+            if (borg_grids[y][x].feat != FEAT_GRANITE
                 && borg_grids[y][x].feat != FEAT_RUBBLE
                 && borg_grids[y][x].feat != FEAT_QUARTZ
                 && borg_grids[y][x].feat != FEAT_MAGMA
@@ -997,10 +995,6 @@ bool borg_excavate_vault(int range)
                     borg_temp_x[ii] = x;
                     borg_temp_y[ii] = y;
                     borg_temp_n++;
-
-                    /* do not overflow */
-                    if (borg_temp_n > AUTO_TEMP_MAX)
-                        borg_temp_n = AUTO_TEMP_MAX;
                 }
             }
         }


### PR DESCRIPTION
Also remove redundant test when extending the list of sites to excavate.

Appears to resolve Grommen's report here, https://angband.live/forums/forum/angband/vanilla/10687-borg-bugs-and-feature-requests?p=248606#post248606 .