### PR TITLE
borg: more tweaks for excavating vaults

### DIFF
--- a/src/borg/borg-cave-view.h
+++ b/src/borg/borg-cave-view.h
@@ -60,6 +60,9 @@
  *
  * The "BORG_XTRA" flag is used for various "extra" purposes, primarily
  * to assist with the "update_view()" code.
+ *
+ * The "BORG_IGNORE_MAP" flag causes the borg to prefer what it thinks
+ * is in a unseen grid to what is returned by map_info().
  */
 #define BORG_MARK  0x01 /* observed grid */
 #define BORG_GLOW  0x02 /* probably perma-lit */
@@ -69,6 +72,7 @@
 #define BORG_VIEW  0x20 /* in line of sight */
 #define BORG_TEMP  0x40 /* temporary flag */
 #define BORG_XTRA  0x80 /* extra flag */
+#define BORG_IGNORE_MAP 0x100 /* ignore unseen grid from map_info() */
 
 /*
  * Maintain a set of grids (viewable grids)

--- a/src/borg/borg-cave.h
+++ b/src/borg/borg-cave.h
@@ -70,16 +70,16 @@ typedef struct borg_grid borg_grid;
  * Hack -- note that the "char" zero will often crash the system!
  */
 struct borg_grid {
-    uint8_t feat; /* Grid type */
-    uint8_t info; /* Grid flags */
-    bool    trap;
-    bool    glyph;
-    uint8_t store;
+    uint8_t  feat; /* Grid type */
+    uint16_t info; /* Grid flags */
+    bool     trap;
+    bool     glyph;
+    uint8_t  store;
 
-    uint8_t take; /* Object index */
-    uint8_t kill; /* Monster index */
+    uint8_t  take; /* Object index */
+    uint8_t  kill; /* Monster index */
 
-    uint8_t xtra; /* Extra field (search count) */
+    uint8_t  xtra; /* Extra field (search count) */
 };
 /*
  * The current map

--- a/src/borg/borg-light.c
+++ b/src/borg/borg-light.c
@@ -438,12 +438,26 @@ bool borg_check_light(void)
             || borg_read_scroll(sv_scroll_mapping)
             || borg_use_staff(sv_staff_mapping) || borg_zap_rod(sv_rod_mapping)
             || borg_spell(SENSE_SURROUNDINGS)) {
+            int y;
+
             borg_note("# Checking for walls.");
 
             borg_react("SELF:wall", "SELF:wall");
 
             borg.when_detect_walls = borg_t;
 
+            /*
+             * Clear the BORG_IGNORE_MAP flag:  immediately after detection
+             * want to use the map's information rather than what the borg
+             * remembers.
+             */
+            for (y = 0; y < AUTO_MAX_Y; ++y) {
+                int x;
+
+                for (x = 0; x < AUTO_MAX_X; ++x) {
+                    borg_grids[y][x].info &= ~BORG_IGNORE_MAP;
+                }
+            }
             return (true);
         }
     }

--- a/src/borg/borg-think-dungeon-util.c
+++ b/src/borg/borg-think-dungeon-util.c
@@ -1020,9 +1020,9 @@ bool borg_excavate_vault(int range)
             borg_note("# Excavation of vault");
             borg_keypress('5');
 
-            /* turn that wall into a floor grid.  If the spell failed, it will
-             * still look like a wall and the borg_update routine will redefine
-             * it as a wall
+            /* turn that wall into a floor grid.  If the spell failed and the
+             * grid is visible, it will still look like a wall and the
+             * borg_update routine will redefine it as a wall
              */
             borg_do_update_view = true;
             borg_do_update_lite = true;
@@ -1033,6 +1033,14 @@ bool borg_excavate_vault(int range)
             borg_grids[borg_temp_y[i]][borg_temp_x[i]].info |= BORG_GLOW;
             /* Feat Floor */
             borg_grids[borg_temp_y[i]][borg_temp_x[i]].feat = FEAT_FLOOR;
+            /*
+             * If the grid is not seen, prefer what the borg remembers over
+             * what map_info() returns (i.e. optimistically assume that the
+             * excavation was successfull.
+             */
+            borg_grids[borg_temp_y[i]][borg_temp_x[i]].info |= BORG_IGNORE_MAP;
+            /* Forget number of mineral veins to force rebuild of vein list */
+            track_vein.num = 0;
 
             return (true);
         }

--- a/src/borg/borg-update.c
+++ b/src/borg/borg-update.c
@@ -283,7 +283,11 @@ static void borg_update_map(void)
             ag->info |= BORG_OKAY;
 
             /* Notice "knowledge" */
-            if (g.f_idx != FEAT_NONE) {
+            if (g.f_idx != FEAT_NONE && (g.in_view
+                    || !(ag->info & BORG_IGNORE_MAP))) {
+                if (g.in_view) {
+                    ag->info &= ~BORG_IGNORE_MAP;
+                }
                 ag->info |= BORG_MARK;
                 ag->feat = g.f_idx;
             }


### PR DESCRIPTION
1) Be willing to ignore what is in the map so the borg does not repeatedly cast stone to mud on a grid that is not seen.
2) Reset the vein list like other digging does.

(1) takes care of the remaining cases I've seen where the borg pauses for extended periods of time repeating "vault excavation" for a grid.