### PR TITLE
borg: fix manual restart regression

### DIFF
--- a/src/borg/borg-commands.c
+++ b/src/borg/borg-commands.c
@@ -1611,7 +1611,7 @@ void do_cmd_borg(void)
              * Force initialization or reinitialize if the game was closed
              * and restarted without exiting since the last initialization
              */
-            if (!borg_initialized) {
+            if (!borg_initialized || game_closed) {
                 if (borg_initialized) {
                     borg_free();
                 }


### PR DESCRIPTION
The regression was introduced, post 4.2.6, in 53d406bf08de2cd839aeb5d2fd6aeb83c82768bf .  Resolves https://github.com/agoodman00/angband/issues/34 .