### PR TITLE
borg: avoid warnings for borg-commands.c on OpenBSD 7.8

### DIFF
--- a/src/borg/borg-commands.c
+++ b/src/borg/borg-commands.c
@@ -360,10 +360,7 @@ static void get_cfg_display(struct menu* menu, int oid, bool cursor, int row,
     c_put_str(label_attr, borg_settings[oid].setting_string, row, col);
 
     if (borg_settings[oid].setting_type == 'b') {
-        if (borg_cfg[oid])
-            strcpy(value, "TRUE");
-        else
-            strcpy(value, "FALSE");
+        my_strcpy(value, (borg_cfg[oid]) ? "TRUE" : "FALSE", sizeof(value));
     }
     else { /* setting type i (integer) */
         snprintf(value, 30, "%d", borg_cfg[oid]);


### PR DESCRIPTION
The compiler was clang 19.1.7 and the linker was LLD 19.1.7.  The warnings were for use of strcpy() (issued by the linker) and no newline at the end of the file (issued by the compiler).